### PR TITLE
Fix LoreTreeMode storage in Firebase

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -474,7 +474,7 @@ document.addEventListener("DOMContentLoaded", () => {
     if (loreTreeMode.checked) {
       const treeWindow = loreTreeFrame.contentWindow;
       if (treeWindow && typeof treeWindow.getSelectedLoreIndexes === "function") {
-        selectedLores = treeWindow.getSelectedLoreIndexes();
+        selectedLores = [...treeWindow.getSelectedLoreIndexes()];
       } else {
         statusMsg.textContent = "❌ Could not get lore from lore tree.";
         return;


### PR DESCRIPTION
In case of using LoreTreeMode it needs to be an array so Firebase can store it.

Error without the fix:

<img width="752" height="326" alt="image" src="https://github.com/user-attachments/assets/a25ea4ee-0bd8-4fe9-847b-72ffe7ee01f4" />

Unsupported field value: a custom Array object (found in field loreOrder in document builds/gzLibP0Gl0xUw8to5HLp)